### PR TITLE
updates after new react-mardown major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ $ npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion chakra-ui-
 import ChakraUIRenderer from 'chakra-ui-markdown-renderer';
 
 <ReactMarkdown
-  renderers={ChakraUIRenderer()}
-  source={markdown}
+  components={ChakraUIRenderer()}
+  children={markdown}
   escapeHtml={false}
 />;
 ```
@@ -43,15 +43,15 @@ import ChakraUIRenderer, { defaults } from 'chakra-ui-markdown-renderer';
 
 const newTheme = {
   ...defaults,
-  paragraph: props => {
+  p: props => {
     const { children } = props;
     return <Text mb={2} fontSize={'12px'}>{children}</Text>;
   },
 }
 
 <ReactMarkdown
-  renderers={ChakraUIRenderer(newTheme)}
-  source={decode(recipeDescription)}
+  components={ChakraUIRenderer(newTheme)}
+  children={decode(recipeDescription)}
   escapeHtml={false}
 />
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,6 @@ export const defaults = {
       </ListItem>
     );
   },
-  definition: () => null,
   heading: props => {
     const { level, children } = props;
     const sizes = ['2xl', 'xl', 'lg', 'md', 'sm', 'xs'];
@@ -122,22 +121,25 @@ export const defaults = {
 
 function ChakraUIRenderer(theme = defaults) {
   return {
-    paragraph: theme.paragraph,
-    emphasis: theme.emphasis,
+    p: theme.paragraph,
+    em: theme.emphasis,
     blockquote: theme.blockquote,
     code: theme.code,
-    delete: theme.delete,
-    thematicBreak: theme.thematicBreak,
-    link: theme.link,
+    del: theme.delete,
+    hr: theme.thematicBreak,
+    a: theme.link,
     img: theme.img,
-    linkReference: theme.linkReference,
-    imageReference: theme.imageReference,
     text: theme.text,
-    list: theme.list,
-    listItem: theme.listItem,
-    definition: theme.definition,
-    heading: theme.heading,
-    inlineCode: theme.inlineCode,
+    ul: theme.list,
+    ol: theme.list,
+    li: theme.listItem,
+    h1: theme.heading,
+    h2: theme.heading,
+    h3: theme.heading,
+    h4: theme.heading,
+    h5: theme.heading,
+    h6: theme.heading,
+    pre: theme.inlineCode,
   };
 }
 


### PR DESCRIPTION
`react-markdown` 6.0.0 has been released and some changes had to be done in order to be compatible.

See the related [changelog](https://github.com/remarkjs/react-markdown/blob/main/changelog.md#change-renderers-to-components) for more information.

This PR might require to bump version.