### PR TITLE
allow react-markdown 8 & chakra-ui 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "deepmerge": "^4.2.2"
   },
   "peerDependencies": {
-    "@chakra-ui/react": "^1.6.1",
-    "react-markdown": "^7"
+    "@chakra-ui/react": "^1.6.1 || ^2",
+    "react-markdown": "^7 || ^8"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",


### PR DESCRIPTION
I tested the package with the newest versions of react-markdown and chakra-ui.
To me, everything seems to work fine. That's why I want to allow them in the peer dependencies.
Thank you.