### PR TITLE
Add support for footnotes.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -139,6 +139,7 @@ export const defaults: Defaults = {
     return (
       <ListItem
         {...getCoreProps(props)}
+        id={props.id}
         listStyleType={checked !== null ? 'none' : 'inherit'}
       >
         {checkbox || children}


### PR DESCRIPTION
Currently chakra-ui-markdown-renderer doesn't support footnotes because it doesn't pass `id` for `li`. This commit just adds `id` to rendered `li`s. (There may be a better way to do this globally, perhaps an allowlist of props.)